### PR TITLE
Add support to parse invalid certs but indicate why they are invalid. 

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/x509/Certificate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/Certificate.java
@@ -7,6 +7,7 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.util.IllegalArgumentWarningException;
 
 /**
  * an X509Certificate structure.
@@ -53,12 +54,19 @@ public class Certificate
     {
         this.seq = seq;
 
+        IllegalArgumentWarningException exception = null;
+
         //
         // correct x509 certficate
         //
         if (seq.size() == 3)
         {
+          try {
             tbsCert = TBSCertificate.getInstance(seq.getObjectAt(0));
+          } catch (IllegalArgumentWarningException ex) {
+            tbsCert = (TBSCertificate) ex.getObject(TBSCertificate.class);
+            exception = ex;
+          }
             sigAlgId = AlgorithmIdentifier.getInstance(seq.getObjectAt(1));
 
             sig = ASN1BitString.getInstance(seq.getObjectAt(2));
@@ -66,6 +74,10 @@ public class Certificate
         else
         {
             throw new IllegalArgumentException("sequence wrong size for a certificate");
+        }
+
+        if (exception != null) {
+          throw new IllegalArgumentWarningException(this, exception);
         }
     }
 
@@ -124,6 +136,7 @@ public class Certificate
         return sig;
     }
 
+    @Override
     public ASN1Primitive toASN1Primitive()
     {
         return seq;

--- a/core/src/main/java/org/bouncycastle/asn1/x509/Extensions.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/Extensions.java
@@ -1,9 +1,5 @@
 package org.bouncycastle.asn1.x509;
 
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.Vector;
-
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Object;
@@ -12,6 +8,11 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.util.IllegalArgumentWarningException;
+
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Vector;
 
 /**
  * <pre>
@@ -71,6 +72,7 @@ public class Extensions
         ASN1Sequence seq)
     {
         Enumeration e = seq.getObjects();
+        String error = null;
 
         while (e.hasMoreElements())
         {
@@ -78,11 +80,16 @@ public class Extensions
 
             if (extensions.containsKey(ext.getExtnId()))
             {
-                throw new IllegalArgumentException("repeated extension found: " + ext.getExtnId());
+                error = "repeated extension found: " + ext.getExtnId();
+                continue;
             }
             
             extensions.put(ext.getExtnId(), ext);
             ordering.addElement(ext.getExtnId());
+        }
+        
+        if (error != null) {
+          throw new IllegalArgumentWarningException(error, this);
         }
     }
 
@@ -163,6 +170,7 @@ public class Extensions
      *        extnValue         OCTET STRING }
      * </pre>
      */
+    @Override
     public ASN1Primitive toASN1Primitive()
     {
         ASN1EncodableVector vec = new ASN1EncodableVector(ordering.size());

--- a/core/src/main/java/org/bouncycastle/asn1/x509/TBSCertificate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/TBSCertificate.java
@@ -156,17 +156,18 @@ public class TBSCertificate
                 if (isV2)
                 {
                   addError("version 2 certificate cannot contain extensions");
-                  return;
+                  throw new IllegalArgumentWarningException(errors, this);
                 }
                 try {
                   extensions = Extensions.getInstance(ASN1Sequence.getInstance(extra, true));
                 } catch (IllegalArgumentWarningException ex) {
-                  extensions = (Extensions) ex.getObject(Extensions.class);
+                  extensions = ex.getObject(Extensions.class);
                   addErrors(ex.getMessages());
                 }
                 break;
             default:
-                throw new IllegalArgumentException("Unknown tag encountered in structure: " + extra.getTagNo());
+              addError("Unknown tag encountered in structure: " + extra.getTagNo());
+              throw new IllegalArgumentWarningException(errors, this);
             }
             extras--;
         }

--- a/core/src/main/java/org/bouncycastle/util/IllegalArgumentWarningException.java
+++ b/core/src/main/java/org/bouncycastle/util/IllegalArgumentWarningException.java
@@ -1,0 +1,41 @@
+package org.bouncycastle.util;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IllegalArgumentWarningException extends IllegalArgumentException {
+  
+  private static final long serialVersionUID = 5735291408274180892L;
+  List<String> messages;
+  Object object;
+  
+  public IllegalArgumentWarningException(List<String> messages, Object object, Throwable cause) {
+    super(messages.get(0), cause);
+    this.messages = messages;
+    this.object = object;
+  }
+
+  public IllegalArgumentWarningException(List<String> messages, Object object) {
+    this(messages, object, null);
+  }
+
+  public IllegalArgumentWarningException(String message, Object object) {
+    this(Collections.singletonList(message), object, null);
+  }
+
+  public IllegalArgumentWarningException(Object object, Throwable cause) {
+    this(Collections.singletonList(cause.getMessage()), object, cause);
+  }
+
+  public List<String> getMessages() {
+    return messages;
+  }
+
+  public <T> T getObject(Class<T> clazz) {
+    if (clazz.isInstance(object)) {
+      return (T) object;
+    }
+    throw new IllegalArgumentException(messages.get(0), this);
+  }
+
+}

--- a/core/src/main/java/org/bouncycastle/util/test/SimpleTest.java
+++ b/core/src/main/java/org/bouncycastle/util/test/SimpleTest.java
@@ -47,7 +47,7 @@ public abstract class SimpleTest
     {
         if (!a.equals(b))
         {
-            throw new TestFailedException(SimpleTestResult.failed(this, "no message"));
+            throw new TestFailedException(SimpleTestResult.failed(this, String.format("isEqual fail: %s != %s", a, b)));
         }
     }
 
@@ -57,7 +57,7 @@ public abstract class SimpleTest
     {
         if (a != b)
         {
-            throw new TestFailedException(SimpleTestResult.failed(this, "no message"));
+            throw new TestFailedException(SimpleTestResult.failed(this, String.format("isEqual fail: %s != %s", a, b)));
         }
     }
 

--- a/prov/src/test/java/org/bouncycastle/jce/provider/test/CertPathValidatorTest.java
+++ b/prov/src/test/java/org/bouncycastle/jce/provider/test/CertPathValidatorTest.java
@@ -582,7 +582,7 @@ public class CertPathValidatorTest
     {
         checkInvalidPath(extInvTrust, extInvCA, extInvEE, "version 1 certificate contains extra data");
         checkInvalidPath(extInvV2Trust, extInvV2CA, extInvV2EE, "version 2 certificate cannot contain extensions");
-        checkInvalidPath(extInvVersionTrust, extInvVersionCA, extInvVersionEE, "version number not recognised");
+        checkInvalidPath(extInvVersionTrust, extInvVersionCA, extInvVersionEE, "Certificate version number value 5 not 0, 1 or 2");
         checkInvalidPath(extInvExtTrust, extInvExtCA, extInvExtEE, "repeated extension found: 2.5.29.15");
     }
 
@@ -621,7 +621,7 @@ public class CertPathValidatorTest
         }
         catch (CertPathValidatorException e)
         {
-            isTrue(e.getMessage().equals(expected));
+          isEquals(e.getMessage(), expected);
         }
 
         // check that our cert factory also rejects - the EE is always the invalid one
@@ -633,7 +633,7 @@ public class CertPathValidatorTest
         }
         catch (CertificateException e)
         {
-            isTrue(e.getMessage().equals("parsing issue: " + expected));
+          isEquals(e.getMessage(), "parsing issue: " + expected);
         }
     }
 


### PR DESCRIPTION
This code essentially creates a subclass of IllegalArgumentException that allows methods that create objects to return the object, but also return an error message as the IllegalArgumentException would have done.

This is needed to parse some certificates visible on the internet. It will also allow us to mark those certificates as bad if they do not conform to the spec.

Merging this PR doesn't actually do anything -- but it sets the stage for adding a jenkins job to build the code and push it to our artifact repository. At that point the pipeline code could be tested in a reasonable way.